### PR TITLE
fix mobile importJs

### DIFF
--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -38,7 +38,13 @@ export class API {
 	 * @param path the vault relative path of the file to import
 	 */
 	public async importJs(path: string): Promise<any> {
-		const fullPath = this.app.vault.adapter.getResourcePath(path);
+		let fullPath = this.app.vault.adapter.getResourcePath(path);
+		if (!fullPath.includes('?')) {
+			const scriptFile = this.app.metadataCache.getFirstLinkpathDest(path, "")
+			if (scriptFile) {
+				fullPath += '?' + scriptFile.stat.mtime
+			}
+		}
 		return import(fullPath);
 	}
 


### PR DESCRIPTION
I'm gonna rewrite here what I've written on Discord to have the context of this PR:

[`DataAdapter.getResourcePath`](https://docs.obsidian.md/Reference/TypeScript+API/DataAdapter/getResourcePath) method doesn't have the same behavior on computer and on mobile. While they both returns the absolute path of the resource passed in parameter, the desktop version append a `?mtime` suffix at the end, which correspond to the file's modified time. This let the `import(fullPath)` in `API.ts` know when the resource can be cached hit or not. Unfortunately since this suffix isn't added on mobile (I'd be interested to know the reason behind this), the import always return the cached version of the file. Thus, only a full reload of the app flush the cache on mobile (I guess)


I think that using [`getFirstLinkpathDest`](https://docs.obsidian.md/Reference/TypeScript+API/MetadataCache/getFirstLinkpathDest), to retrieve a TFile of the imported script is the cleanest workaround. That way I can append the `TFile.mtime` directly at the end of path to optimize cache hits.