### PR TITLE
Implement hot reload for `engine.importJs`

### DIFF
--- a/JsEngine.d.ts
+++ b/JsEngine.d.ts
@@ -896,15 +896,15 @@ declare module 'jsEngine/api/Internal' {
 	import type { API } from 'jsEngine/api/API';
 	import type { EngineExecutionParams } from 'jsEngine/engine/Engine';
 	import type {
-		JsExecution,
 		ExecutionContext,
+		JsExecution,
 		JsExecutionGlobals,
 		JsExecutionGlobalsConstructionOptions,
-		MarkdownCodeBlockExecutionContext,
 		JSFileExecutionContext,
-		UnknownExecutionContext,
 		MarkdownCallingJSFileExecutionContext,
+		MarkdownCodeBlockExecutionContext,
 		MarkdownOtherExecutionContext,
+		UnknownExecutionContext,
 	} from 'jsEngine/engine/JsExecution';
 	import { ResultRenderer } from 'jsEngine/engine/ResultRenderer';
 	import { Component } from 'obsidian';
@@ -1303,8 +1303,9 @@ declare module 'jsEngine/api/API' {
 		 * you might need to reload Obsidian to see changes made to the imported file.
 		 *
 		 * @param path the vault relative path of the file to import
+		 * @param hotReload whether to reload the imported module (may cause memory shortage if abused)
 		 */
-		importJs(path: string): Promise<unknown>;
+		importJs(path: string, hotReload?: boolean): Promise<unknown>;
 		/**
 		 * Gets a plugin by its id. A plugin id can be found by looking at its manifest.
 		 * If the plugin is not enabled, this will return undefined.
@@ -1354,8 +1355,8 @@ declare module 'jsEngine/engine/JsExecution' {
 	import type { EngineExecutionParams } from 'jsEngine/engine/Engine';
 	import type JsEnginePlugin from 'jsEngine/main';
 	import type { MessageWrapper } from 'jsEngine/messages/MessageManager';
-	import type { App, CachedMetadata, Component, TFile } from 'obsidian';
 	import type * as Obsidian from 'obsidian';
+	import type { App, CachedMetadata, Component, TFile } from 'obsidian';
 	/**
 	 * An async JavaScript function.
 	 */
@@ -1559,24 +1560,24 @@ declare module 'jsEngine/JsMDRC' {
 	}
 }
 declare module 'jsEngine/index' {
-	export * from 'jsEngine/engine/Engine';
-	export * from 'jsEngine/engine/JsExecution';
-	export * from 'jsEngine/engine/ResultRenderer';
 	export * from 'jsEngine/api/API';
 	export * from 'jsEngine/api/InstanceId';
 	export * from 'jsEngine/api/Internal';
 	export * from 'jsEngine/api/LibAPI';
+	export * from 'jsEngine/api/markdown/AbstractMarkdownElement';
+	export * from 'jsEngine/api/markdown/AbstractMarkdownElementContainer';
+	export * from 'jsEngine/api/markdown/AbstractMarkdownLiteral';
+	export * from 'jsEngine/api/markdown/MarkdownBuilder';
+	export * from 'jsEngine/api/markdown/MarkdownElementType';
+	export * from 'jsEngine/api/markdown/MarkdownString';
 	export * from 'jsEngine/api/MarkdownAPI';
 	export * from 'jsEngine/api/MessageAPI';
 	export * from 'jsEngine/api/PromptAPI';
 	export * from 'jsEngine/api/QueryAPI';
 	export * from 'jsEngine/api/reactive/ReactiveComponent';
-	export * from 'jsEngine/api/markdown/AbstractMarkdownElement';
-	export * from 'jsEngine/api/markdown/AbstractMarkdownElementContainer';
-	export * from 'jsEngine/api/markdown/AbstractMarkdownLiteral';
-	export * from 'jsEngine/api/markdown/MarkdownString';
-	export * from 'jsEngine/api/markdown/MarkdownBuilder';
-	export * from 'jsEngine/api/markdown/MarkdownElementType';
+	export * from 'jsEngine/engine/Engine';
+	export * from 'jsEngine/engine/JsExecution';
+	export * from 'jsEngine/engine/ResultRenderer';
 }
 declare module 'jsEngine/utils/UseIcon' {
 	export function useIcon(

--- a/jsEngine/api/API.ts
+++ b/jsEngine/api/API.ts
@@ -70,8 +70,9 @@ export class API {
 	 * you might need to reload Obsidian to see changes made to the imported file.
 	 *
 	 * @param path the vault relative path of the file to import
+	 * @param hotReload whether to reload the imported module (may cause memory shortage if abused)
 	 */
-	public async importJs(path: string): Promise<unknown> {
+	public async importJs(path: string, hotReload = false): Promise<unknown> {
 		validateAPIArgs(z.object({ path: z.string() }), { path });
 
 		let fullPath = this.app.vault.adapter.getResourcePath(path);
@@ -81,6 +82,11 @@ export class API {
 		// and we would end up with multiple imports of the same file
 		// which would cause things like `instanceof` to produce false negatives
 		fullPath = fullPath.split('?')[0];
+
+		if (hotReload) {
+			// Trick from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import
+			fullPath += `?t=${Date.now()}`;
+		}
 
 		return import(fullPath);
 	}


### PR DESCRIPTION
I am using this plugin to add some interactivity to my notes. The JS code I write is kind of big, so, to avoid cluttering my note, I write the business logic in a separate JS file that I import using `engine.importJs()`.

However, Obsidian caches the imports made by `engine.importJs`. Therefore, when re-running the code block, the `engine.importJs('path/to/my/script.js')` does not actually reload my `script.js` after I made changes to it. This considerably slows down my development as I have to continually reload Obsidian for the changes to take effect.

This PR implements a hot reload feature to actually load the script every time the code blocks is re-run.

:bulb:  **Hot reload is disabled by default, for backwards compatibility and to save memory.**

:warning: **It may cause memory shortage if abused (and other bugs with `instanceof`, I read your comments), but it will considerably improve DX.**

(Thank you for your hard work, Moritz Jung!)
